### PR TITLE
cuda-command-line-tools v12.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,12 @@ source:
 
 build:
   number: 0
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   run:
     - cuda-cupti-dev 12.9.79
     # There is no `cuda-gdb` support on Windows so it is skipped.
-    # Also `cuda-gdb` should be supported on `ppc64le`, but is currently broken.
-    # xref: https://github.com/conda-forge/cuda-command-line-tools-feedstock/issues/6
     - cuda-gdb 12.9.79       # [linux]
     - cuda-nvdisasm 12.9.88
     - cuda-nvprof 12.9.79    # [linux64 or win]
@@ -33,10 +31,12 @@ about:
   license_file: LICENSE.txt
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Meta-package containing the command line tools to debug CUDA applications
   description: |
     Meta-package containing the command line tools to debug CUDA applications
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-command-line-tools 12.9.1

**Destination channel:** defaults

### Links

- [PKG-12793](https://anaconda.atlassian.net/browse/PKG-12793) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's conda-forge/cuda-command-line-tools-feedstock@8207ba1b19c7861f1b4e94f892216b3aada06857 commit.
- This is a meta-package


[PKG-12793]: https://anaconda.atlassian.net/browse/PKG-12793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ