### PR TITLE
cuda-command-line-tools v13.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.0.2" %}
+{% set version = "13.0.3" %}
 
 package:
   name: cuda-command-line-tools


### PR DESCRIPTION
cuda-command-line-tools 13.0.3

**Destination channel:** defaults

### Links

- [PKG-13776](https://anaconda.atlassian.net/browse/PKG-13776) 
- [CUDA 13.0.3 Release Notes](https://docs.nvidia.com/cuda/archive/13.0.3/cuda-toolkit-release-notes/index.html#id5)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Synchronize with upstream feedstock's [13.0 branch](https://github.com/conda-forge/cuda-command-line-tools-feedstock/tree/13.0)
- Version bump


[PKG-13776]: https://anaconda.atlassian.net/browse/PKG-13776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ